### PR TITLE
[CN-2583] add page refresh delay and resolve overlapping requests

### DIFF
--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -60,20 +60,7 @@ export const PipelineExecutions = ({
       return;
     }
 
-    const requestParams = {
-      pipelineName: pipeline.name,
-      pageSize: REQUEST_PAGE_SIZE,
-      startDate: dateRange.start,
-      endDate: dateRange.end,
-    };
-
-    gate.getExecutions(appName, requestParams).then((resp) => {
-      setExecutions(resp);
-      setFilteredExecutions(filterExecutions(resp));
-      setStatusCount(getStatusCount(resp));
-      setIsLoading(false);
-      setIsRequestInProgress(false);
-    });
+    getExecutions(appName, getExecutionsParams);
   }, [pipeline, dateRange.start, dateRange.end]);
 
   useEffect(() => {
@@ -94,23 +81,29 @@ export const PipelineExecutions = ({
       console.log("end useInterval");
       return;
     }
-    
-    setIsRequestInProgress(true);
-    console.log("making a request...");
-    const resp = await gate.getExecutions(appName, {
-      pipelineName: pipeline.name,
-      pageSize: REQUEST_PAGE_SIZE,
-      startDate: dateRange.start,
-      endDate: dateRange.end,
-    });
-    console.log("request completed");
-    setExecutions(resp);
-    setFilteredExecutions(filterExecutions(resp));
-    setStatusCount(getStatusCount(resp));
-    setIsLoading(false);
-    setIsRequestInProgress(false);
+
+    getExecutions(appName, getExecutionsParams);
     console.log("end useInterval");
   }, POLL_DELAY_MS);
+
+  const getExecutions = (name, params) => {
+    setIsRequestInProgress(true);
+    console.log("making a request...");
+
+    gate.getExecutions(name, params)
+      .then((resp) => {
+        console.log("request completed");
+
+        setExecutions(resp);
+        setFilteredExecutions(filterExecutions(resp));
+        setStatusCount(getStatusCount(resp));
+        setIsLoading(false);
+      })
+      .catch((e) => console.error('error retrieving executions: ', e))
+      .finally(() => {
+        setIsRequestInProgress(false);
+      });
+  };
 
   const filterExecutions = (ex: IExecution[]) => {
     const statusArr = statuses.length === 0 ? STATUSES : statuses;

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -104,10 +104,9 @@ export const PipelineExecutions = ({
 
     setTimeout(() => {
       console.log('setting timeout');
+      setIsRequestInProgress(false);
+      console.log("request completed");
     }, 40000);
-
-    setIsRequestInProgress(false);
-    console.log("request completed");
 
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -56,6 +56,7 @@ export const PipelineExecutions = ({
       setFilteredExecutions([]);
       setStatusCount(new Map<string, number>());
       setIsLoading(false);
+      setIsRequestInProgress(false);
       return;
     }
 
@@ -71,6 +72,7 @@ export const PipelineExecutions = ({
       setFilteredExecutions(filterExecutions(resp));
       setStatusCount(getStatusCount(resp));
       setIsLoading(false);
+      setIsRequestInProgress(false);
     });
   }, [pipeline, dateRange.start, dateRange.end]);
 

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -72,28 +72,18 @@ export const PipelineExecutions = ({
   }, [statuses]);
 
   useInterval(async () => {
-    console.log("start useInterval");
-
     if (!pipeline) return;
 
-    if (isRequestInProgress) {
-      console.log("request is in progress");
-      console.log("end useInterval");
-      return;
-    }
+    if (isRequestInProgress) return;
 
     getExecutions(appName, getExecutionsParams);
-    console.log("end useInterval");
   }, POLL_DELAY_MS);
 
   const getExecutions = (name, params) => {
     setIsRequestInProgress(true);
-    console.log("making a request...");
 
     gate.getExecutions(name, params)
       .then((resp) => {
-        console.log("request completed");
-
         setExecutions(resp);
         setFilteredExecutions(filterExecutions(resp));
         setStatusCount(getStatusCount(resp));
@@ -101,7 +91,6 @@ export const PipelineExecutions = ({
       })
       .catch((e) => console.error('error retrieving executions: ', e))
       .finally(() => {
-        console.log('setIsRequestInProgress = false')
         setIsRequestInProgress(false);
       });
   };

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -83,18 +83,11 @@ export const PipelineExecutions = ({
   }, [statuses]);
 
   useInterval(async () => {
-    console.log("start useInterval");
-
     if (!pipeline) return;
 
-    if (isRequestInProgress) {
-      console.log("request is in progress");
-      return;
-    }
+    if (isRequestInProgress) return;
     
     setIsRequestInProgress(true);
-    console.log("making a request...");
-
     const resp = await gate.getExecutions(appName, {
       pipelineName: pipeline.name,
       pageSize: REQUEST_PAGE_SIZE,
@@ -102,18 +95,11 @@ export const PipelineExecutions = ({
       endDate: dateRange.end,
     });
 
-    setTimeout(() => {
-      console.log('setting timeout');
-      setIsRequestInProgress(false);
-      console.log("request completed");
-    }, 40000);
-
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));
     setStatusCount(getStatusCount(resp));
     setIsLoading(false);
-
-    console.log("end useInterval");
+    setIsRequestInProgress(false);
   }, POLL_DELAY_MS);
 
   const filterExecutions = (ex: IExecution[]) => {

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -93,7 +93,7 @@ export const PipelineExecutions = ({
     }
     
     setIsRequestInProgress(true);
-    console.log('making a request...');
+    console.log("making a request...");
 
     const resp = await gate.getExecutions(appName, {
       pipelineName: pipeline.name,
@@ -103,7 +103,7 @@ export const PipelineExecutions = ({
     });
 
     setIsRequestInProgress(false);
-    console.log('request completed.');
+    console.log("request completed.");
 
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -36,6 +36,7 @@ export const PipelineExecutions = ({
   const [filteredExecutions, setFilteredExecutions] = useState<IExecution[]>([]);
   const [statusCount, setStatusCount] = useState<Map<string, number>>(new Map<string, number>());
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isRequestInProgress, setIsRequestInProgress] = useState<boolean>(false);
   const styles = useStyles();
 
   const getExecutionsParams = {
@@ -82,7 +83,18 @@ export const PipelineExecutions = ({
   }, [statuses]);
 
   useInterval(async () => {
+    console.log("start useInterval");
+
     if (!pipeline) return;
+
+    if (isRequestInProgress) {
+      console.log("request is in progress");
+      return;
+    }
+    
+    setIsRequestInProgress(true);
+    console.log('making a request...');
+
     const resp = await gate.getExecutions(appName, {
       pipelineName: pipeline.name,
       pageSize: REQUEST_PAGE_SIZE,
@@ -90,10 +102,15 @@ export const PipelineExecutions = ({
       endDate: dateRange.end,
     });
 
+    setIsRequestInProgress(false);
+    console.log('request completed.');
+
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));
     setStatusCount(getStatusCount(resp));
     setIsLoading(false);
+
+    console.log("end useInterval");
   }, POLL_DELAY_MS);
 
   const filterExecutions = (ex: IExecution[]) => {

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -101,6 +101,7 @@ export const PipelineExecutions = ({
       })
       .catch((e) => console.error('error retrieving executions: ', e))
       .finally(() => {
+        console.log('setIsRequestInProgress = false')
         setIsRequestInProgress(false);
       });
   };

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -102,8 +102,12 @@ export const PipelineExecutions = ({
       endDate: dateRange.end,
     });
 
+    setTimeout(() => {
+      console.log('setting timeout');
+    }, 40000);
+
     setIsRequestInProgress(false);
-    console.log("request completed.");
+    console.log("request completed");
 
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));

--- a/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
+++ b/spin-observatory-plugin-deck/src/components/pipelines/PipelineExecutions.tsx
@@ -85,23 +85,31 @@ export const PipelineExecutions = ({
   }, [statuses]);
 
   useInterval(async () => {
+    console.log("start useInterval");
+
     if (!pipeline) return;
 
-    if (isRequestInProgress) return;
+    if (isRequestInProgress) {
+      console.log("request is in progress");
+      console.log("end useInterval");
+      return;
+    }
     
     setIsRequestInProgress(true);
+    console.log("making a request...");
     const resp = await gate.getExecutions(appName, {
       pipelineName: pipeline.name,
       pageSize: REQUEST_PAGE_SIZE,
       startDate: dateRange.start,
       endDate: dateRange.end,
     });
-
+    console.log("request completed");
     setExecutions(resp);
     setFilteredExecutions(filterExecutions(resp));
     setStatusCount(getStatusCount(resp));
     setIsLoading(false);
     setIsRequestInProgress(false);
+    console.log("end useInterval");
   }, POLL_DELAY_MS);
 
   const filterExecutions = (ex: IExecution[]) => {

--- a/spin-observatory-plugin-deck/src/components/pipelines/constants.ts
+++ b/spin-observatory-plugin-deck/src/components/pipelines/constants.ts
@@ -2,6 +2,6 @@ export const REQUEST_PAGE_SIZE = 5000;
 
 export const DEFAULT_ROWS_PER_PAGE = 10;
 
-export const POLL_DELAY_MS = 10000;
+export const POLL_DELAY_MS = 30000;
 
 export const MAX_DATE_RANGE = 9007199254740991;


### PR DESCRIPTION
**Happy Path**

Initial request made when pipeline is selected
<img width="1724" alt="1" src="https://github.com/homedepot/spin-observatory-plugin/assets/5687567/c43e529f-9406-481e-8ed8-00be80d0db8d">

2nd request made after 30s, response has timeout of 40s
<img width="1724" alt="2" src="https://github.com/homedepot/spin-observatory-plugin/assets/5687567/ffc572b6-0fac-4954-85d8-4b2cce32bb55">

On the next 30s interval, request is skipped due to request already in progress and waiting for response
<img width="1724" alt="3" src="https://github.com/homedepot/spin-observatory-plugin/assets/5687567/9be1459d-d393-4edf-94c9-7d15dd75cb5a">

2nd request completes before the next 30s interval
<img width="1724" alt="4" src="https://github.com/homedepot/spin-observatory-plugin/assets/5687567/7baef1c2-2160-49ae-be66-ebd5aac88be6">

New request is made on the next 30s interval
<img width="1724" alt="5" src="https://github.com/homedepot/spin-observatory-plugin/assets/5687567/01d6dd4f-8d00-4fa1-93f7-62946b927f36">

**Unhappy Path**

Request made to refresh page and waits for response
![waiting-for-error](https://github.com/homedepot/spin-observatory-plugin/assets/5687567/639e42b2-c0ab-4de0-9fd9-e6e134cad7db)

Request fails, sets flag to false, and makes a 2nd request at the next 30s interval
![continues-requests-after-failure](https://github.com/homedepot/spin-observatory-plugin/assets/5687567/ee997ccb-4972-4cf3-8d1c-61d3e8b95609)

Note: Utilized console logs for testing purposes.
